### PR TITLE
Fix duplicated responses error

### DIFF
--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -5,22 +5,30 @@ if (!process.env.OPENAI_API_KEY) {
   throw new Error("Missing env var from OpenAI");
 }
 
+const interviewSystemContent = `You are helping a software developer apprentice write a portfolio for their training programme, ask them questions about their job and projects they've worked on. Don't go into too much detail, you only need a basic overview of these. When you have a basic overview of their job and their work projects, say goodbye and end the conversation`;
+
+let conversationHistory = [
+  {
+    role: "system",
+    content: interviewSystemContent
+  }
+];
+
 export const POST = async (req: Request): Promise<Response> => {
-  const messages = await req.json();
+  const newMessage = await req.json();
+
+  conversationHistory.push(newMessage);
 
   const payload: OpenAIStreamPayload = {
     model: "gpt-3.5-turbo",
-    messages: [
-      { role: "system", content: interviewSystemContent },
-      ...messages,
-    ],
+    messages: conversationHistory,
     temperature: 1,
     top_p: 1,
     frequency_penalty: 0,
     presence_penalty: 0,
     max_tokens: 1000,
     stream: true,
-    n: 1,
+    n: 1
   };
 
   const response = await openAINotStreamed(payload);
@@ -28,8 +36,6 @@ export const POST = async (req: Request): Promise<Response> => {
   /* const stream = await OpenAIStream(payload);
   return new Response(stream); */
 };
-
-const interviewSystemContent = `You are helping a software developer apprentice write a portfolio for their training programme, ask them questions about their job and projects they've worked on. Don't go into too much detail, you only need a basic overview of these. When you have a basic overview of their job and their work projects, say goodbye and end the conversation`;
 
 const skeletonsystemContent = `You are helping an apprentice write their portfolio, they will describe the place they work and you will return a JSON object with the structure of their portfolio. The apprentice will then fill in the details.
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -30,7 +30,7 @@ export default function Home() {
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify(messages),
+      body: JSON.stringify({ role: "user", content: inputContent }),
     });
 
     if (response.status === 400) {

--- a/utils/openAIStream.ts
+++ b/utils/openAIStream.ts
@@ -11,7 +11,7 @@ import { ChatCompletionCreateParams } from "openai/resources/index.mjs";
 // typescript with newer features like function calls. Right now I've installed the openai library
 // just to get access to the Function interface.
 
-export type ChatGPTAgent = "user" | "system" | "assistant";
+export type ChatGPTAgent = "user" | "system" | "assistant" | string;
 
 export interface ChatGPTMessage {
   role: ChatGPTAgent;


### PR DESCRIPTION
There was an error where each question was asked twice. To fix this issue, we only send the last user input to the chatbot each time instead of all the previous messages.